### PR TITLE
feat: アニメーション係数を外部から設定可能にする

### DIFF
--- a/app/src/main/java/io/github/katsukia/stackablecards/CardList.kt
+++ b/app/src/main/java/io/github/katsukia/stackablecards/CardList.kt
@@ -23,11 +23,27 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
+/**
+ * A scrollable list of cards that stack on top of each other as you scroll.
+ *
+ * @param count The number of cards to display.
+ * @param modifier The modifier to apply to this composable.
+ * @param cardSpacing The spacing between cards.
+ * @param cardScaleFactor The factor by which to scale down cards as they scroll.
+ * @param cardTranslationFactor The factor by which to translate cards as they scroll.
+ * @param cardAlphaFactor The factor by which to decrease the alpha of cards as they scroll.
+ * @param cardShadowAlphaFactor The factor by which to increase the shadow alpha of cards as they scroll.
+ * @param content The content of each card.
+ */
 @Composable
 fun CardList(
     count: Int,
     modifier: Modifier = Modifier,
     cardSpacing: Dp = 8.dp,
+    cardScaleFactor: Float = CardDefaults.cardScaleFactor,
+    cardTranslationFactor: Float = CardDefaults.cardTranslationFactor,
+    cardAlphaFactor: Float = CardDefaults.cardAlphaFactor,
+    cardShadowAlphaFactor: Float = CardDefaults.cardShadowAlphaFactor,
     content: @Composable (index: Int) -> Unit,
 ) {
     val listState = rememberLazyListState()
@@ -47,17 +63,35 @@ fun CardList(
                 cardSpacingPx = cardSpacingPx,
                 firstVisibleItemIndex = firstVisibleItemIndex,
                 firstVisibleItemScrollOffsetPx = firstVisibleItemScrollOffset,
+                cardScaleFactor = cardScaleFactor,
+                cardTranslationFactor = cardTranslationFactor,
+                cardAlphaFactor = cardAlphaFactor,
+                cardShadowAlphaFactor = cardShadowAlphaFactor,
                 content = content
             )
         }
     }
 }
 
+/**
+ * Converts a float value to Dp.
+ */
 @Composable
 private fun Float.toDp(): Dp {
     return with(LocalDensity.current) { this@toDp.toDp() }
 }
 
+/**
+ * CardListの各アイテムを表示するコンポーザブル。
+ * スクロール位置に基づいてカードのアニメーション効果（スケール、透明度、影など）を適用します。
+ *
+ * @param index カードのインデックス
+ * @param cardSpacingPx カード間の間隔（ピクセル単位）
+ * @param firstVisibleItemIndex 表示されている最初のアイテムのインデックス
+ * @param firstVisibleItemScrollOffsetPx 表示されている最初のアイテムのスクロールオフセット（ピクセル単位）
+ * @param modifier このコンポーザブルに適用する[Modifier]
+ * @param content カードの内容を定義するコンポーザブル関数
+ */
 @Composable
 private fun CardListItem(
     index: Int,
@@ -65,6 +99,10 @@ private fun CardListItem(
     firstVisibleItemIndex: Int,
     firstVisibleItemScrollOffsetPx: Float,
     modifier: Modifier = Modifier,
+    cardScaleFactor: Float,
+    cardTranslationFactor: Float,
+    cardAlphaFactor: Float,
+    cardShadowAlphaFactor: Float,
     content: @Composable (index: Int) -> Unit,
 ) {
     var cardHeightPx by remember { mutableFloatStateOf(0f) }
@@ -73,7 +111,11 @@ private fun CardListItem(
         cardSpacingPx = cardSpacingPx,
         firstVisibleItemIndex = firstVisibleItemIndex,
         firstVisibleItemScrollOffsetPx = firstVisibleItemScrollOffsetPx,
-        cardHeightPx = cardHeightPx
+        cardHeightPx = cardHeightPx,
+        cardScaleFactor = cardScaleFactor,
+        cardTranslationFactor = cardTranslationFactor,
+        cardAlphaFactor = cardAlphaFactor,
+        cardShadowAlphaFactor = cardShadowAlphaFactor,
     )
     Card(
         modifier = modifier.graphicsLayer {
@@ -89,6 +131,7 @@ private fun CardListItem(
             }
         ) {
             content(index)
+            // Overlay a shadow on top of the card
             Box(
                 modifier = Modifier
                     .height(cardHeightPx.toDp())
@@ -99,6 +142,9 @@ private fun CardListItem(
     }
 }
 
+/**
+ * Holds the state for the graphics layer of a card.
+ */
 private data class CardGraphicsLayerState(
     val translationY: Float,
     val scale: Float,
@@ -106,13 +152,20 @@ private data class CardGraphicsLayerState(
     val shadowAlpha: Float
 )
 
+/**
+ * Calculates and remembers the graphics layer state for a card based on the scroll position.
+ */
 @Composable
 private fun rememberCardGraphicsLayerState(
     index: Int,
     cardSpacingPx: Float,
     firstVisibleItemIndex: Int,
     firstVisibleItemScrollOffsetPx: Float,
-    cardHeightPx: Float
+    cardHeightPx: Float,
+    cardScaleFactor: Float,
+    cardTranslationFactor: Float,
+    cardAlphaFactor: Float,
+    cardShadowAlphaFactor: Float,
 ): CardGraphicsLayerState {
     val offset = if (firstVisibleItemIndex >= index && cardHeightPx > 0f) {
         val offsetRatio = firstVisibleItemScrollOffsetPx / (cardHeightPx + cardSpacingPx)
@@ -121,10 +174,10 @@ private fun rememberCardGraphicsLayerState(
         0f
     }
     return remember(offset, cardHeightPx) {
-        val cardScale = 1f - offset * CardScaleFactor
-        val cardTranslationY = offset * (cardHeightPx + cardSpacingPx) * CardTranslationFactor
-        val cardAlpha = if (offset < 1f) 1f else (1f - (offset - 1f) * CardAlphaFactor).coerceIn(0f, 1f)
-        val cardShadowAlpha = (offset * CardShadowAlphaFactor).coerceIn(0f, 1f)
+        val cardScale = 1f - offset * cardScaleFactor
+        val cardTranslationY = offset * (cardHeightPx + cardSpacingPx) * cardTranslationFactor
+        val cardAlpha = if (offset < 1f) 1f else (1f - (offset - 1f) * cardAlphaFactor).coerceIn(0f, 1f)
+        val cardShadowAlpha = (offset * cardShadowAlphaFactor).coerceIn(0f, 1f)
         CardGraphicsLayerState(
             translationY = cardTranslationY,
             scale = cardScale,
@@ -134,7 +187,13 @@ private fun rememberCardGraphicsLayerState(
     }
 }
 
-private const val CardScaleFactor = 0.05f
-private const val CardTranslationFactor = 0.95f
-private const val CardAlphaFactor = 10f
-private const val CardShadowAlphaFactor = 0.2f
+object CardDefaults {
+    /** The factor by which to scale down cards as they scroll. */
+    const val cardScaleFactor = 0.05f
+    /** The factor by which to translate cards as they scroll. */
+    const val cardTranslationFactor = 0.95f
+    /** The factor by which to decrease the alpha of cards as they scroll. */
+    const val cardAlphaFactor = 10f
+    /** The factor by which to increase the shadow alpha of cards as they scroll. */
+    const val cardShadowAlphaFactor = 0.2f
+}

--- a/app/src/main/java/io/github/katsukia/stackablecards/MainActivity.kt
+++ b/app/src/main/java/io/github/katsukia/stackablecards/MainActivity.kt
@@ -4,11 +4,17 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -21,18 +27,53 @@ class MainActivity : ComponentActivity() {
         setContent {
             SampleMaterialTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    CardList(
-                        count = 100,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(innerPadding),
-                        content = { index ->
-                            Text(
-                                modifier = Modifier.padding(16.dp),
-                                text = "Card $index",
+                    var cardScaleFactor by remember { mutableFloatStateOf(CardDefaults.cardScaleFactor) }
+                    var cardTranslationFactor by remember { mutableFloatStateOf(CardDefaults.cardTranslationFactor) }
+                    var cardAlphaFactor by remember { mutableFloatStateOf(CardDefaults.cardAlphaFactor) }
+                    var cardShadowAlphaFactor by remember { mutableFloatStateOf(CardDefaults.cardShadowAlphaFactor) }
+
+                    Column(modifier = Modifier.padding(innerPadding)) {
+                        CardList(
+                            count = 100,
+                            modifier = Modifier.weight(1f),
+                            cardScaleFactor = cardScaleFactor,
+                            cardTranslationFactor = cardTranslationFactor,
+                            cardAlphaFactor = cardAlphaFactor,
+                            cardShadowAlphaFactor = cardShadowAlphaFactor,
+                            content = { index ->
+                                Text(
+                                    modifier = Modifier.padding(16.dp),
+                                    text = "Card $index",
+                                )
+                            },
+                        )
+                        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                            Text(text = "cardScaleFactor: %.2f".format(cardScaleFactor))
+                            Slider(
+                                value = cardScaleFactor,
+                                onValueChange = { cardScaleFactor = it },
+                                valueRange = 0f..1f,
                             )
-                        },
-                    )
+                            Text(text = "cardTranslationFactor: %.2f".format(cardTranslationFactor))
+                            Slider(
+                                value = cardTranslationFactor,
+                                onValueChange = { cardTranslationFactor = it },
+                                valueRange = 0f..1f,
+                            )
+                            Text(text = "cardAlphaFactor: %.2f".format(cardAlphaFactor))
+                            Slider(
+                                value = cardAlphaFactor,
+                                onValueChange = { cardAlphaFactor = it },
+                                valueRange = 0f..20f,
+                            )
+                            Text(text = "cardShadowAlphaFactor: %.2f".format(cardShadowAlphaFactor))
+                            Slider(
+                                value = cardShadowAlphaFactor,
+                                onValueChange = { cardShadowAlphaFactor = it },
+                                valueRange = 0f..1f,
+                            )
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 概要

`CardList`コンポーザブルのアニメーション関連の係数（`cardScaleFactor`, `cardTranslationFactor`など）を外部から注入できるようにし、コンポーネントの再利用性とカスタマイズ性を向上させました。

## 変更点

- `CardList`コンポーザブルに、アニメーションの挙動を制御するための引数を追加しました。
- 各係数のデフォルト値を`CardDefaults`オブジェクトで提供するようにしました。
- `MainActivity`に`Slider`コントロールを追加し、リアルタイムで各係数を変更してアニメーションの変化を確認できるサンプルUIを実装しました。

---

*This pull request was created with the assistance of gemini-cli.*