### PR TITLE
feat: アニメーション調整UIのモーダル化と状態管理のリファクタリング

### DIFF
--- a/app/src/main/java/io/github/katsukia/stackablecards/AnimationSettingsSheet.kt
+++ b/app/src/main/java/io/github/katsukia/stackablecards/AnimationSettingsSheet.kt
@@ -1,0 +1,100 @@
+package io.github.katsukia.stackablecards
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+/**
+ * A bottom sheet content composable for adjusting animation parameters.
+ *
+ * @param animationFactors The current animation factors.
+ * @param onAnimationFactorsChange A callback to be invoked when the animation factors change.
+ * @param onResetClick A callback to be invoked when the reset button is clicked.
+ * @param modifier The modifier to apply to this composable.
+ */
+@Composable
+fun AnimationSettingsSheet(
+    animationFactors: CardAnimationFactors,
+    onAnimationFactorsChange: (CardAnimationFactors) -> Unit,
+    onResetClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.padding(16.dp)) {
+        Text(
+            text = stringResource(id = R.string.settings_title),
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        SettingSlider(
+            label = stringResource(R.string.scale_factor_label),
+            description = stringResource(id = R.string.scale_factor_desc),
+            value = animationFactors.scaleFactor,
+            onValueChange = { onAnimationFactorsChange(animationFactors.copy(scaleFactor = it)) },
+            valueRange = 0f..1f
+        )
+
+        SettingSlider(
+            label = stringResource(R.string.translation_factor_label),
+            description = stringResource(id = R.string.translation_factor_desc),
+            value = animationFactors.translationFactor,
+            onValueChange = { onAnimationFactorsChange(animationFactors.copy(translationFactor = it)) },
+            valueRange = 0f..1f
+        )
+
+        SettingSlider(
+            label = stringResource(R.string.alpha_factor_label),
+            description = stringResource(id = R.string.alpha_factor_desc),
+            value = animationFactors.alphaFactor,
+            onValueChange = { onAnimationFactorsChange(animationFactors.copy(alphaFactor = it)) },
+            valueRange = 0f..20f
+        )
+
+        SettingSlider(
+            label = stringResource(R.string.shadow_alpha_factor_label),
+            description = stringResource(id = R.string.shadow_alpha_factor_desc),
+            value = animationFactors.shadowAlphaFactor,
+            onValueChange = { onAnimationFactorsChange(animationFactors.copy(shadowAlphaFactor = it)) },
+            valueRange = 0f..1f
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = onResetClick, modifier = Modifier.fillMaxWidth()) {
+            Text(text = stringResource(id = R.string.reset_button_label))
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun SettingSlider(
+    label: String,
+    description: String,
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    valueRange: ClosedFloatingPointRange<Float>,
+) {
+    Column {
+        Text(text = "$label: %.2f".format(value), style = MaterialTheme.typography.bodyLarge)
+        Text(text = description, style = MaterialTheme.typography.bodySmall)
+        Slider(
+            value = value,
+            onValueChange = onValueChange,
+            valueRange = valueRange,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+}

--- a/app/src/main/java/io/github/katsukia/stackablecards/CardAnimationFactors.kt
+++ b/app/src/main/java/io/github/katsukia/stackablecards/CardAnimationFactors.kt
@@ -1,0 +1,19 @@
+package io.github.katsukia.stackablecards
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * A data class that holds the animation factors for the cards.
+ *
+ * @property scaleFactor The factor by which to scale down cards as they scroll.
+ * @property translationFactor The factor by which to translate cards as they scroll.
+ * @property alphaFactor The factor by which to decrease the alpha of cards as they scroll.
+ * @property shadowAlphaFactor The factor by which to increase the shadow alpha of cards as they scroll.
+ */
+@Immutable
+data class CardAnimationFactors(
+    val scaleFactor: Float = 0.05f,
+    val translationFactor: Float = 0.95f,
+    val alphaFactor: Float = 10f,
+    val shadowAlphaFactor: Float = 0.2f
+)

--- a/app/src/main/java/io/github/katsukia/stackablecards/CardList.kt
+++ b/app/src/main/java/io/github/katsukia/stackablecards/CardList.kt
@@ -40,10 +40,7 @@ fun CardList(
     count: Int,
     modifier: Modifier = Modifier,
     cardSpacing: Dp = 8.dp,
-    cardScaleFactor: Float = CardDefaults.cardScaleFactor,
-    cardTranslationFactor: Float = CardDefaults.cardTranslationFactor,
-    cardAlphaFactor: Float = CardDefaults.cardAlphaFactor,
-    cardShadowAlphaFactor: Float = CardDefaults.cardShadowAlphaFactor,
+    animationFactors: CardAnimationFactors = CardAnimationFactors(),
     content: @Composable (index: Int) -> Unit,
 ) {
     val listState = rememberLazyListState()
@@ -63,10 +60,7 @@ fun CardList(
                 cardSpacingPx = cardSpacingPx,
                 firstVisibleItemIndex = firstVisibleItemIndex,
                 firstVisibleItemScrollOffsetPx = firstVisibleItemScrollOffset,
-                cardScaleFactor = cardScaleFactor,
-                cardTranslationFactor = cardTranslationFactor,
-                cardAlphaFactor = cardAlphaFactor,
-                cardShadowAlphaFactor = cardShadowAlphaFactor,
+                animationFactors = animationFactors,
                 content = content
             )
         }
@@ -99,10 +93,7 @@ private fun CardListItem(
     firstVisibleItemIndex: Int,
     firstVisibleItemScrollOffsetPx: Float,
     modifier: Modifier = Modifier,
-    cardScaleFactor: Float,
-    cardTranslationFactor: Float,
-    cardAlphaFactor: Float,
-    cardShadowAlphaFactor: Float,
+    animationFactors: CardAnimationFactors,
     content: @Composable (index: Int) -> Unit,
 ) {
     var cardHeightPx by remember { mutableFloatStateOf(0f) }
@@ -112,10 +103,7 @@ private fun CardListItem(
         firstVisibleItemIndex = firstVisibleItemIndex,
         firstVisibleItemScrollOffsetPx = firstVisibleItemScrollOffsetPx,
         cardHeightPx = cardHeightPx,
-        cardScaleFactor = cardScaleFactor,
-        cardTranslationFactor = cardTranslationFactor,
-        cardAlphaFactor = cardAlphaFactor,
-        cardShadowAlphaFactor = cardShadowAlphaFactor,
+        animationFactors = animationFactors,
     )
     Card(
         modifier = modifier.graphicsLayer {
@@ -162,10 +150,7 @@ private fun rememberCardGraphicsLayerState(
     firstVisibleItemIndex: Int,
     firstVisibleItemScrollOffsetPx: Float,
     cardHeightPx: Float,
-    cardScaleFactor: Float,
-    cardTranslationFactor: Float,
-    cardAlphaFactor: Float,
-    cardShadowAlphaFactor: Float,
+    animationFactors: CardAnimationFactors,
 ): CardGraphicsLayerState {
     val offset = if (firstVisibleItemIndex >= index && cardHeightPx > 0f) {
         val offsetRatio = firstVisibleItemScrollOffsetPx / (cardHeightPx + cardSpacingPx)
@@ -173,11 +158,11 @@ private fun rememberCardGraphicsLayerState(
     } else {
         0f
     }
-    return remember(offset, cardHeightPx) {
-        val cardScale = 1f - offset * cardScaleFactor
-        val cardTranslationY = offset * (cardHeightPx + cardSpacingPx) * cardTranslationFactor
-        val cardAlpha = if (offset < 1f) 1f else (1f - (offset - 1f) * cardAlphaFactor).coerceIn(0f, 1f)
-        val cardShadowAlpha = (offset * cardShadowAlphaFactor).coerceIn(0f, 1f)
+    return remember(offset, cardHeightPx, animationFactors) {
+        val cardScale = 1f - offset * animationFactors.scaleFactor
+        val cardTranslationY = offset * (cardHeightPx + cardSpacingPx) * animationFactors.translationFactor
+        val cardAlpha = if (offset < 1f) 1f else (1f - (offset - 1f) * animationFactors.alphaFactor).coerceIn(0f, 1f)
+        val cardShadowAlpha = (offset * animationFactors.shadowAlphaFactor).coerceIn(0f, 1f)
         CardGraphicsLayerState(
             translationY = cardTranslationY,
             scale = cardScale,
@@ -187,13 +172,4 @@ private fun rememberCardGraphicsLayerState(
     }
 }
 
-object CardDefaults {
-    /** The factor by which to scale down cards as they scroll. */
-    const val cardScaleFactor = 0.05f
-    /** The factor by which to translate cards as they scroll. */
-    const val cardTranslationFactor = 0.95f
-    /** The factor by which to decrease the alpha of cards as they scroll. */
-    const val cardAlphaFactor = 10f
-    /** The factor by which to increase the shadow alpha of cards as they scroll. */
-    const val cardShadowAlphaFactor = 0.2f
-}
+

--- a/app/src/main/java/io/github/katsukia/stackablecards/MainActivity.kt
+++ b/app/src/main/java/io/github/katsukia/stackablecards/MainActivity.kt
@@ -4,15 +4,20 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -21,56 +26,48 @@ import androidx.compose.ui.unit.dp
 import io.github.katsukia.stackablecards.ui.theme.SampleMaterialTheme
 
 class MainActivity : ComponentActivity() {
+    @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             SampleMaterialTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    var cardScaleFactor by remember { mutableFloatStateOf(CardDefaults.cardScaleFactor) }
-                    var cardTranslationFactor by remember { mutableFloatStateOf(CardDefaults.cardTranslationFactor) }
-                    var cardAlphaFactor by remember { mutableFloatStateOf(CardDefaults.cardAlphaFactor) }
-                    var cardShadowAlphaFactor by remember { mutableFloatStateOf(CardDefaults.cardShadowAlphaFactor) }
+                val sheetState = rememberModalBottomSheetState()
+                var showBottomSheet by remember { mutableStateOf(false) }
 
-                    Column(modifier = Modifier.padding(innerPadding)) {
-                        CardList(
-                            count = 100,
-                            modifier = Modifier.weight(1f),
-                            cardScaleFactor = cardScaleFactor,
-                            cardTranslationFactor = cardTranslationFactor,
-                            cardAlphaFactor = cardAlphaFactor,
-                            cardShadowAlphaFactor = cardShadowAlphaFactor,
-                            content = { index ->
-                                Text(
-                                    modifier = Modifier.padding(16.dp),
-                                    text = "Card $index",
-                                )
-                            },
-                        )
-                        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-                            Text(text = "cardScaleFactor: %.2f".format(cardScaleFactor))
-                            Slider(
-                                value = cardScaleFactor,
-                                onValueChange = { cardScaleFactor = it },
-                                valueRange = 0f..1f,
+                var animationFactors by remember { mutableStateOf(CardAnimationFactors()) }
+
+                Scaffold(
+                    modifier = Modifier.fillMaxSize(),
+                    floatingActionButton = {
+                        FloatingActionButton(onClick = { showBottomSheet = true }) {
+                            Icon(Icons.Default.Settings, contentDescription = "Open animation settings")
+                        }
+                    }
+                ) { innerPadding ->
+                    CardList(
+                        count = 100,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
+                        animationFactors = animationFactors,
+                        content = { index ->
+                            Text(
+                                modifier = Modifier.padding(16.dp),
+                                text = "Card $index",
                             )
-                            Text(text = "cardTranslationFactor: %.2f".format(cardTranslationFactor))
-                            Slider(
-                                value = cardTranslationFactor,
-                                onValueChange = { cardTranslationFactor = it },
-                                valueRange = 0f..1f,
-                            )
-                            Text(text = "cardAlphaFactor: %.2f".format(cardAlphaFactor))
-                            Slider(
-                                value = cardAlphaFactor,
-                                onValueChange = { cardAlphaFactor = it },
-                                valueRange = 0f..20f,
-                            )
-                            Text(text = "cardShadowAlphaFactor: %.2f".format(cardShadowAlphaFactor))
-                            Slider(
-                                value = cardShadowAlphaFactor,
-                                onValueChange = { cardShadowAlphaFactor = it },
-                                valueRange = 0f..1f,
+                        },
+                    )
+
+                    if (showBottomSheet) {
+                        ModalBottomSheet(
+                            onDismissRequest = { showBottomSheet = false },
+                            sheetState = sheetState
+                        ) {
+                            AnimationSettingsSheet(
+                                animationFactors = animationFactors,
+                                onAnimationFactorsChange = { animationFactors = it },
+                                onResetClick = { animationFactors = CardAnimationFactors() }
                             )
                         }
                     }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,13 @@
+<resources>
+    <string name="app_name">StackableCardsCompose</string>
+    <string name="settings_title">アニメーション設定</string>
+    <string name="scale_factor_label">縮小係数</string>
+    <string name="scale_factor_desc">背景に移動したカードがどれだけ縮小されるかを制御します。</string>
+    <string name="translation_factor_label">移動係数</string>
+    <string name="translation_factor_desc">背景に移動したカードがどれだけ下に移動するかを制御します。</string>
+    <string name="alpha_factor_label">透明度係数</string>
+    <string name="alpha_factor_desc">背景に移動したカードがどれだけ速くフェードアウトするかを制御します。</string>
+    <string name="shadow_alpha_factor_label">影の透明度係数</string>
+    <string name="shadow_alpha_factor_desc">背景のカードにかかる影の暗さを制御します。</string>
+    <string name="reset_button_label">デフォルトに戻す</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,13 @@
 <resources>
-    <string name="app_name">stackable-cards-compose</string>
+    <string name="app_name">StackableCardsCompose</string>
+    <string name="settings_title">Animation Settings</string>
+    <string name="scale_factor_label">Scale Factor</string>
+    <string name="scale_factor_desc">Controls how much the cards shrink as they go into the background.</string>
+    <string name="translation_factor_label">Translation Factor</string>
+    <string name="translation_factor_desc">Controls how much the cards move down as they go into the background.</string>
+    <string name="alpha_factor_label">Alpha Factor</string>
+    <string name="alpha_factor_desc">Controls how quickly the cards fade out as they go into the background.</string>
+    <string name="shadow_alpha_factor_label">Shadow Alpha Factor</string>
+    <string name="shadow_alpha_factor_desc">Controls the darkness of the shadow on the cards in the background.</string>
+    <string name="reset_button_label">Reset to defaults</string>
 </resources>


### PR DESCRIPTION
### 変更点
- FABをタップするとアニメーション係数を調整するモーダル(BottomSheet)が表示されるようにしました。
- 調整UIを`AnimationSettingsSheet`コンポーザブルとして`MainActivity`から分離しました。
- アニメーション係数を`CardAnimationFactors`データクラスに集約し、状態管理を単一の`State`で行うようにリファクタリングしました。
- モーダル内に、係数をデフォルト値に戻すリセットボタンを追加しました。

---

*This pull request was created with the assistance of gemini-cli.*