### PR TITLE
feat: CardListの汎用化：縦横両方のスクロール方向に対応

### DIFF
--- a/app/src/main/java/io/github/katsukia/stackablecards/AnimationSettingsSheet.kt
+++ b/app/src/main/java/io/github/katsukia/stackablecards/AnimationSettingsSheet.kt
@@ -1,6 +1,9 @@
 package io.github.katsukia.stackablecards
 
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -29,6 +32,8 @@ fun AnimationSettingsSheet(
     onAnimationFactorsChange: (CardAnimationFactors) -> Unit,
     onResetClick: () -> Unit,
     modifier: Modifier = Modifier,
+    orientation: Orientation,
+    onOrientationChange: (Orientation) -> Unit,
 ) {
     Column(modifier = modifier.padding(16.dp)) {
         Text(
@@ -37,6 +42,28 @@ fun AnimationSettingsSheet(
             modifier = Modifier.fillMaxWidth(),
             textAlign = TextAlign.Center
         )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Button(
+                onClick = { onOrientationChange(Orientation.Vertical) },
+                enabled = orientation != Orientation.Vertical,
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(text = "Vertical")
+            }
+            Button(
+                onClick = { onOrientationChange(Orientation.Horizontal) },
+                enabled = orientation != Orientation.Horizontal,
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(text = "Horizontal")
+            }
+        }
+
         Spacer(modifier = Modifier.height(16.dp))
 
         SettingSlider(

--- a/app/src/main/java/io/github/katsukia/stackablecards/MainActivity.kt
+++ b/app/src/main/java/io/github/katsukia/stackablecards/MainActivity.kt
@@ -4,8 +4,11 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -36,6 +39,7 @@ class MainActivity : ComponentActivity() {
                 var showBottomSheet by remember { mutableStateOf(false) }
 
                 var animationFactors by remember { mutableStateOf(CardAnimationFactors()) }
+                var orientation by remember { mutableStateOf(Orientation.Vertical) }
 
                 Scaffold(
                     modifier = Modifier.fillMaxSize(),
@@ -45,15 +49,24 @@ class MainActivity : ComponentActivity() {
                         }
                     }
                 ) { innerPadding ->
+                    val contentModifier =
+                        if (orientation == Orientation.Vertical) {
+                            Modifier.padding(16.dp)
+                        } else {
+                            Modifier
+                                .width(150.dp)
+                                .padding(16.dp)
+                        }
                     CardList(
                         count = 100,
                         modifier = Modifier
                             .fillMaxSize()
                             .padding(innerPadding),
                         animationFactors = animationFactors,
+                        orientation = orientation,
                         content = { index ->
                             Text(
-                                modifier = Modifier.padding(16.dp),
+                                modifier = contentModifier,
                                 text = "Card $index",
                             )
                         },
@@ -67,7 +80,9 @@ class MainActivity : ComponentActivity() {
                             AnimationSettingsSheet(
                                 animationFactors = animationFactors,
                                 onAnimationFactorsChange = { animationFactors = it },
-                                onResetClick = { animationFactors = CardAnimationFactors() }
+                                onResetClick = { animationFactors = CardAnimationFactors() },
+                                orientation = orientation,
+                                onOrientationChange = { orientation = it },
                             )
                         }
                     }


### PR DESCRIPTION
## 変更の概要
コンポーネントをリファクタリングし、従来の縦スクロールに加えて横スクロールにも対応できるように一般化しました。

### 主な変更点
- **パラメータの導入:**
  - にパラメータを追加し、（縦）と（横）を動的に切り替えられるようにしました。

- **動的なレイアウトとアニメーション:**
  - アニメーションロジック（/）やサイズ計測を、スクロール方向に応じて自動で適応するように修正しました。
  - これにより、コンポーネントはコンテンツ自身のサイズ（縦スクロールなら高さ、横スクロールなら幅）に追従する、真に汎用的な作りになりました。

- **サンプルアプリの更新:**
  - サンプルアプリに設定画面（モーダルボトムシート）を追加し、縦スクロールと横スクロールのデモを動的に切り替えて確認できるようにしました。

ご確認のほど、よろしくお願いいたします。