### PR TITLE
feat: CardListとMainActivityのリファクタリング

### DIFF
--- a/app/src/main/java/io/github/katsukia/stackablecards/CardList.kt
+++ b/app/src/main/java/io/github/katsukia/stackablecards/CardList.kt
@@ -5,11 +5,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -20,7 +21,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Outline
-import androidx.compose.material3.CardDefaults
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -44,6 +44,7 @@ fun CardList(
     orientation: Orientation = Orientation.Vertical,
     cardSpacing: Dp = 8.dp,
     animationFactors: CardAnimationFactors = CardAnimationFactors(),
+    contentPadding: PaddingValues = if (orientation == Orientation.Vertical) PaddingValues(horizontal = 16.dp) else PaddingValues(vertical = 16.dp),
     content: @Composable (index: Int) -> Unit,
 ) {
     val listState = rememberLazyListState()
@@ -51,46 +52,38 @@ fun CardList(
     val firstVisibleItemScrollOffset by remember { derivedStateOf { listState.firstVisibleItemScrollOffset.toFloat() } }
     val cardSpacingPx = with(LocalDensity.current) { cardSpacing.toPx() }
 
+    val listContent: LazyListScope.() -> Unit = {
+        items(count = count) { index ->
+            CardListItem(
+                index = index,
+                cardSpacingPx = cardSpacingPx,
+                firstVisibleItemIndex = firstVisibleItemIndex,
+                firstVisibleItemScrollOffsetPx = firstVisibleItemScrollOffset,
+                animationFactors = animationFactors,
+                orientation = orientation,
+                content = content
+            )
+        }
+    }
+
     when (orientation) {
         Orientation.Vertical -> {
             LazyColumn(
                 modifier = modifier,
                 state = listState,
-                contentPadding = PaddingValues(horizontal = 16.dp),
+                contentPadding = contentPadding,
                 verticalArrangement = Arrangement.spacedBy(cardSpacing),
-            ) {
-                items(count = count) { index ->
-                    CardListItem(
-                        index = index,
-                        cardSpacingPx = cardSpacingPx,
-                        firstVisibleItemIndex = firstVisibleItemIndex,
-                        firstVisibleItemScrollOffsetPx = firstVisibleItemScrollOffset,
-                        animationFactors = animationFactors,
-                        orientation = orientation,
-                        content = content
-                    )
-                }
-            }
+                content = listContent,
+            )
         }
         Orientation.Horizontal -> {
             LazyRow(
                 modifier = modifier,
                 state = listState,
-                contentPadding = PaddingValues(vertical = 16.dp),
+                contentPadding = contentPadding,
                 horizontalArrangement = Arrangement.spacedBy(cardSpacing),
-            ) {
-                items(count = count) { index ->
-                    CardListItem(
-                        index = index,
-                        cardSpacingPx = cardSpacingPx,
-                        firstVisibleItemIndex = firstVisibleItemIndex,
-                        firstVisibleItemScrollOffsetPx = firstVisibleItemScrollOffset,
-                        animationFactors = animationFactors,
-                        orientation = orientation,
-                        content = content
-                    )
-                }
-            }
+                content = listContent,
+            )
         }
     }
 }
@@ -251,5 +244,3 @@ private fun rememberCardGraphicsLayerState(
         )
     }
 }
-
-

--- a/app/src/main/java/io/github/katsukia/stackablecards/MainActivity.kt
+++ b/app/src/main/java/io/github/katsukia/stackablecards/MainActivity.kt
@@ -5,10 +5,8 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -18,13 +16,11 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.katsukia.stackablecards.ui.theme.SampleMaterialTheme
 
@@ -49,14 +45,7 @@ class MainActivity : ComponentActivity() {
                         }
                     }
                 ) { innerPadding ->
-                    val contentModifier =
-                        if (orientation == Orientation.Vertical) {
-                            Modifier.padding(16.dp)
-                        } else {
-                            Modifier
-                                .width(150.dp)
-                                .padding(16.dp)
-                        }
+                    
                     CardList(
                         count = 100,
                         modifier = Modifier
@@ -66,7 +55,7 @@ class MainActivity : ComponentActivity() {
                         orientation = orientation,
                         content = { index ->
                             Text(
-                                modifier = contentModifier,
+                                modifier = Modifier.padding(16.dp),
                                 text = "Card $index",
                             )
                         },
@@ -92,18 +81,3 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    SampleMaterialTheme {
-        Greeting("Android")
-    }
-}


### PR DESCRIPTION
`CardList.kt` と `MainActivity.kt` のリファクタリングを実施しました。

### 主な変更点
- **`CardList.kt`**
  - `LazyColumn` と `LazyRow` で重複していた `items` のロジックを共通化
  - `contentPadding` を外部から指定可能に変更
- **`MainActivity.kt`**
  - 不要な `Greeting` サンプルコードを削除
  - `CardList` の呼び出し箇所を `contentPadding` の変更に合わせて修正

gemini-cliで作成